### PR TITLE
Add instructions for temporary demo env

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@
 			target="_blank"
 		/>
 	</a>
+	<br/>
+	<a href="https://kelda.io/preview-env/?repo=https://github.com/cedalo/streamsheets.git&composeFiles=deployment/standard/installer/services/docker-compose/docker-compose.prod.yml&port=reverseproxy:8081&env=VERSION=1.4">
+		<img
+			alt="Blimp demo badge"
+			src="https://kelda.io/demo-badge.svg?repo=https://github.com/cedalo/streamsheets.git"
+			target="_blank"
+		/>
+	</a>
 </div>
 
 <br/>
@@ -102,6 +110,18 @@ Example
 ```
 docker run -v ~/streamsheets:/streamsheets cedalo/streamsheets-installer:2.0-linux
 ```
+
+### Temporary demo environment
+
+If you want to play around with Streamsheets without running it locally, you can
+[boot a personal demo copy
+](https://kelda.io/preview-env/?repo=https://github.com/cedalo/streamsheets.git&composeFiles=deployment/standard/installer/services/docker-compose/docker-compose.prod.yml&port=reverseproxy:8081&env=VERSION=1.4)
+from your browser without downloading or setting up anything.
+
+Clicking the
+[link](https://kelda.io/preview-env/?repo=https://github.com/cedalo/streamsheets.git&composeFiles=deployment/standard/installer/services/docker-compose/docker-compose.prod.yml&port=reverseproxy:8081&env=VERSION=1.4)
+boots this repo in the Blimp cloud, and creates a public URL for you to access
+it.
 
 <!-- ### Running from source code
 


### PR DESCRIPTION
Hi @cleancoderocker, @ejj reached out a couple weeks about building a way to spin up demo envs for Streamsheets. We've finished the first version!

<img width="1420" alt="Screen Shot 2020-09-13 at 3 52 09 PM" src="https://user-images.githubusercontent.com/1811185/93030612-19eea500-f5d9-11ea-9824-0c8f7af317cc.png">

The demo env works great for me -- I was able to fully complete the dogs & cats example in the getting started.

What do you think? Does it still seem useful?